### PR TITLE
Add avatar support to user data and menu

### DIFF
--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
   const { data: profile } = await sb.from('profiles').select('*').eq('id', user.id).single();
   const freeLimit = 2 + (profile?.quota_extra || 0);
   return NextResponse.json({
-    user,
+    user: { ...user, avatar_url: profile?.avatar_url || null },
     quota: { used: profile?.quota_used || 0, limit: freeLimit, extraUnlocked: (profile?.quota_extra || 0) > 0 },
     plan: profile?.plan || 'FREE',
   });

--- a/app/components/UserMenu.tsx
+++ b/app/components/UserMenu.tsx
@@ -31,8 +31,16 @@ export default function UserMenu() {
 
   return (
     <div className="relative">
-      <button ref={btnRef} onClick={() => setOpen((v) => !v)} className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white text-neutral-900 text-sm font-bold">
-        {(user.email || 'U').slice(0, 1).toUpperCase()}
+      <button
+        ref={btnRef}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-white text-neutral-900 text-sm font-bold"
+      >
+        {user.avatar_url ? (
+          <img src={user.avatar_url} alt="User avatar" className="h-full w-full object-cover" />
+        ) : (
+          (user.email || 'U').slice(0, 1).toUpperCase()
+        )}
       </button>
       {open && (
         <div ref={menuRef} role="menu" aria-label="User menu" onKeyDown={onKeyDown} tabIndex={-1} className="absolute right-0 mt-2 w-56 rounded-2xl border border-white/10 bg-neutral-900/90 p-2 shadow-xl">

--- a/app/providers/UserProvider.tsx
+++ b/app/providers/UserProvider.tsx
@@ -4,8 +4,14 @@ import useSWR, { mutate } from 'swr';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
 
 type Quota = { used: number; limit: number; extraUnlocked: boolean } | null;
+interface User {
+  email?: string | null;
+  avatar_url?: string | null;
+  [key: string]: any;
+}
+
 type UserState = {
-  user: any | null;
+  user: User | null;
   plan: string | null;
   quota: Quota;
   loading: boolean;


### PR DESCRIPTION
## Summary
- include `avatar_url` in `/api/me` response and context
- show user avatar in `UserMenu` when available

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68999f8659088332ad6ef836e7917aca