### PR TITLE
Improve profile editor form

### DIFF
--- a/app/components/ProfileEditor.tsx
+++ b/app/components/ProfileEditor.tsx
@@ -2,6 +2,25 @@
 import React, { useState } from 'react';
 import { useUser } from '@/app/providers/UserProvider';
 
+const TIMEZONES = [
+  'UTC',
+  'America/New_York',
+  'America/Los_Angeles',
+  'Europe/London',
+  'Europe/Paris',
+  'Asia/Tokyo',
+  'Australia/Sydney',
+];
+
+const LOCALES = [
+  { value: 'en', label: 'English' },
+  { value: 'es', label: 'Spanish' },
+  { value: 'fr', label: 'French' },
+  { value: 'de', label: 'German' },
+  { value: 'ja', label: 'Japanese' },
+  { value: 'zh', label: 'Chinese' },
+];
+
 export default function ProfileEditor({
   initialDisplayName,
   initialAvatarUrl,
@@ -52,36 +71,99 @@ export default function ProfileEditor({
   };
 
   return (
-    <div className="rounded-2xl border border-white/10 bg-neutral-900/60 p-5 space-y-4">
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSave();
+      }}
+      className="rounded-2xl border border-white/10 bg-neutral-900/60 p-5 space-y-4"
+    >
       <div>
-        <div className="text-sm text-white/60">Display name</div>
-        <input value={displayName} onChange={(e)=>setDisplayName(e.target.value)} maxLength={80} className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-cyan-400/60" />
+        <label htmlFor="displayName" className="text-sm text-white/60">
+          Display name
+        </label>
+        <input
+          id="displayName"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          maxLength={80}
+          className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-cyan-400/60"
+        />
       </div>
       <div>
-        <div className="text-sm text-white/60">Avatar URL</div>
-        <input value={avatarUrl} onChange={(e)=>setAvatarUrl(e.target.value)} className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-cyan-400/60" />
+        <label htmlFor="avatarUrl" className="text-sm text-white/60">
+          Avatar URL
+        </label>
+        <input
+          id="avatarUrl"
+          value={avatarUrl}
+          onChange={(e) => setAvatarUrl(e.target.value)}
+          className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-cyan-400/60"
+        />
       </div>
       <div className="flex items-center gap-3">
-        <input id="mkt" type="checkbox" checked={marketingOptIn} onChange={(e)=>setMarketingOptIn(e.target.checked)} className="h-4 w-4" />
-        <label htmlFor="mkt" className="text-sm text-white/80">I’d like to receive product tips and updates</label>
+        <input
+          id="mkt"
+          type="checkbox"
+          checked={marketingOptIn}
+          onChange={(e) => setMarketingOptIn(e.target.checked)}
+          className="h-4 w-4"
+        />
+        <label htmlFor="mkt" className="text-sm text-white/80">
+          I’d like to receive product tips and updates
+        </label>
       </div>
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <div className="text-sm text-white/60">Timezone</div>
-          <input value={timezone} onChange={(e)=>setTimezone(e.target.value)} className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-cyan-400/60" />
+          <label htmlFor="timezone" className="text-sm text-white/60">
+            Timezone
+          </label>
+          <select
+            id="timezone"
+            value={timezone}
+            onChange={(e) => setTimezone(e.target.value)}
+            className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-cyan-400/60"
+          >
+            {TIMEZONES.map((tz) => (
+              <option key={tz} value={tz}>
+                {tz}
+              </option>
+            ))}
+          </select>
         </div>
         <div>
-          <div className="text-sm text-white/60">Locale</div>
-          <input value={locale} onChange={(e)=>setLocale(e.target.value)} className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-cyan-400/60" />
+          <label htmlFor="locale" className="text-sm text-white/60">
+            Locale
+          </label>
+          <select
+            id="locale"
+            value={locale}
+            onChange={(e) => setLocale(e.target.value)}
+            className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-cyan-400/60"
+          >
+            {LOCALES.map((loc) => (
+              <option key={loc.value} value={loc.value}>
+                {loc.label}
+              </option>
+            ))}
+          </select>
         </div>
       </div>
       <div className="flex items-center gap-3">
-        <button onClick={onSave} disabled={saving} className={saving?"rounded-2xl bg-white/60 text-neutral-900 px-4 py-2 font-semibold cursor-not-allowed":"rounded-2xl bg-white text-neutral-900 px-4 py-2 font-semibold hover:opacity-90"}>
+        <button
+          type="submit"
+          disabled={saving}
+          className={
+            saving
+              ? 'rounded-2xl bg-white/60 text-neutral-900 px-4 py-2 font-semibold cursor-not-allowed'
+              : 'rounded-2xl bg-white text-neutral-900 px-4 py-2 font-semibold hover:opacity-90'
+          }
+        >
           {saving ? 'Saving…' : 'Save changes'}
         </button>
         {msg && <span className="text-sm text-white/70">{msg}</span>}
       </div>
-    </div>
+    </form>
   );
 }
 


### PR DESCRIPTION
## Summary
- use real `<label>` elements tied to inputs
- support Enter key by submitting form
- switch timezone and locale to dropdowns with curated options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires manual ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68999f8947808332ac808c85d187475d