### PR TITLE
Add shared layout for account pages

### DIFF
--- a/app/(app)/account/page.tsx
+++ b/app/(app)/account/page.tsx
@@ -1,11 +1,10 @@
-import { redirect } from 'next/navigation';
 import { supabaseServer } from '@/lib/supabaseServer';
 import ProfileEditor from '@/app/components/ProfileEditor';
 
 export default async function AccountPage() {
   const sb = supabaseServer();
   const { data: { user } } = await sb.auth.getUser();
-  if (!user) redirect('/?returnTo=/account');
+  if (!user) return null; // Auth enforced by layout
 
   const { data: profile } = await sb.from('profiles').select('*').eq('id', user.id).single();
   const plan = profile?.plan || 'FREE';

--- a/app/(app)/billing/page.tsx
+++ b/app/(app)/billing/page.tsx
@@ -1,10 +1,9 @@
-import { redirect } from 'next/navigation';
 import { supabaseServer } from '@/lib/supabaseServer';
 
 export default async function BillingPage() {
   const sb = supabaseServer();
   const { data: { user } } = await sb.auth.getUser();
-  if (!user) redirect('/?returnTo=/billing');
+  if (!user) return null; // Auth enforced by layout
 
   const { data: profile } = await sb.from('profiles').select('*').eq('id', user.id).single();
   const plan = profile?.plan || 'FREE';

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import UserMenu from '@/app/components/UserMenu';
+import { supabaseServer } from '@/lib/supabaseServer';
+
+export default async function AppLayout({ children }: { children: ReactNode }) {
+  const sb = supabaseServer();
+  const { data: { user } } = await sb.auth.getUser();
+  if (!user) {
+    const path = headers().get('x-pathname') ?? '/';
+    redirect(`/?returnTo=${encodeURIComponent(path)}`);
+  }
+  return (
+    <>
+      <header className="sticky top-0 z-40 border-b border-white/10 bg-neutral-900/80 backdrop-blur supports-[backdrop-filter]:bg-neutral-900/60">
+        <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+          <a href="/" className="text-sm text-white/70 hover:text-white">
+            &larr; Back to app
+          </a>
+          <UserMenu />
+        </div>
+      </header>
+      {children}
+    </>
+  );
+}
+

--- a/app/(app)/usage/page.tsx
+++ b/app/(app)/usage/page.tsx
@@ -1,10 +1,9 @@
-import { redirect } from 'next/navigation';
 import { supabaseServer } from '@/lib/supabaseServer';
 
 export default async function UsagePage() {
   const sb = supabaseServer();
   const { data: { user } } = await sb.auth.getUser();
-  if (!user) redirect('/?returnTo=/usage');
+  if (!user) return null; // Auth enforced by layout
 
   const { data: profile } = await sb.from('profiles').select('*').eq('id', user.id).single();
   const plan = profile?.plan || 'FREE';


### PR DESCRIPTION
## Summary
- add layout for authenticated app pages with header, back link, and UserMenu
- rely on layout for auth in account, billing, and usage pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(config prompt displayed)*

------
https://chatgpt.com/codex/tasks/task_e_68999f87e6208332aae714757e6e8656