### PR TITLE
Add AI pipeline with schemas and provider

### DIFF
--- a/lib/ai/index.ts
+++ b/lib/ai/index.ts
@@ -1,14 +1,9 @@
 import type { Payload } from '@/lib/generator';
 import type { Outputs } from '@/types/kit';
-import { generateOutputsWithOpenAI } from './openai';
+import { generateKit } from './pipeline';
 
 export async function generateOutputsWithAI(payload: Payload, plan: 'FREE' | 'PRO' | 'TEAM' = 'FREE'): Promise<Outputs> {
-  const provider = (process.env.AI_PROVIDER || 'openai').toLowerCase();
-  if (provider === 'openai') {
-    return generateOutputsWithOpenAI(payload, plan);
-  }
-  // Default to OpenAI if unknown provider
-  return generateOutputsWithOpenAI(payload, plan);
+  const { outputs } = await generateKit(payload, plan);
+  return outputs;
 }
-
 

--- a/lib/ai/pipeline.ts
+++ b/lib/ai/pipeline.ts
@@ -1,0 +1,101 @@
+import type { Payload } from '@/lib/generator';
+import type { Output, Facts } from './schemas';
+import { FactsSchema, OutputSchema } from './schemas';
+import { callProvider, ChatMessage } from './provider';
+
+// Normalize and sanitize incoming payload values.
+export function buildFacts(payload: Payload): Facts {
+  const features = (payload.features || [])
+    .map((f) => f.trim())
+    .filter(Boolean)
+    .slice(0, 10);
+  const raw = {
+    address: payload.address?.trim(),
+    neighborhood: payload.neighborhood?.trim(),
+    beds: payload.beds?.trim(),
+    baths: payload.baths?.trim(),
+    sqft: payload.sqft?.trim(),
+    features,
+    propertyType: payload.propertyType?.trim(),
+    tone: payload.tone?.trim(),
+    brandVoice: payload.brandVoice?.trim(),
+  } as Record<string, any>;
+  return FactsSchema.parse(raw);
+}
+
+function composeDraftMessages(facts: Facts): ChatMessage[] {
+  return [
+    {
+      role: 'system',
+      content:
+        'You are a real-estate copywriter. Produce MLS-compliant, fair-housing-safe content. Output JSON only matching the schema exactly.',
+    },
+    {
+      role: 'user',
+      content: `Facts: ${JSON.stringify(facts)}`,
+    },
+  ];
+}
+
+function composeCritiqueMessages(facts: Facts, draft: Output): ChatMessage[] {
+  return [
+    {
+      role: 'system',
+      content:
+        'You are a real-estate copywriter and critical editor. Ensure outputs comply with MLS and fair-housing rules. Output final JSON only.',
+    },
+    {
+      role: 'user',
+      content: `Facts: ${JSON.stringify(facts)}\nDraft: ${JSON.stringify(draft)}`,
+    },
+  ];
+}
+
+// Apply length caps and trimming to model output.
+function postProcess(o: Output): Output {
+  const trim = (s: string) => s.trim();
+  const cap = (s: string, n: number) => (s.length > n ? s.slice(0, n) : s);
+  return {
+    mlsDesc: trim(cap(o.mlsDesc || '', 900)),
+    igSlides: (o.igSlides || []).map((s) => trim(cap(s, 110))).slice(0, 7),
+    reelScript: (o.reelScript || []).map((s) => trim(cap(s, 200))).slice(0, 3),
+    emailSubject: trim(cap(o.emailSubject || '', 70)),
+    emailBody: trim(cap(o.emailBody || '', 900)),
+  };
+}
+
+// Basic compliance scan for problematic terms. Returns a list of flags.
+function complianceScan(o: Output): string[] {
+  const banned = ['school', 'crime', 'demographic', 'race'];
+  const text = [
+    o.mlsDesc,
+    ...o.igSlides,
+    ...o.reelScript,
+    o.emailSubject,
+    o.emailBody,
+  ]
+    .join(' ')
+    .toLowerCase();
+  return banned.filter((b) => text.includes(b));
+}
+
+const PROMPT_VERSION = '1';
+const RULES_VERSION = '1';
+
+export async function generateKit(
+  payload: Payload,
+  plan: 'FREE' | 'PRO' | 'TEAM' = 'FREE'
+): Promise<{ outputs: Output; flags: string[]; promptVersion: string; rulesVersion: string }> {
+  const facts = buildFacts(payload);
+  const draft = await callProvider(composeDraftMessages(facts), plan);
+  let final = draft;
+  try {
+    final = await callProvider(composeCritiqueMessages(facts, draft), plan);
+  } catch (err) {
+    console.warn('[pipeline] critique pass failed', err);
+  }
+  const outputs = postProcess(OutputSchema.parse(final));
+  const flags = complianceScan(outputs);
+  return { outputs, flags, promptVersion: PROMPT_VERSION, rulesVersion: RULES_VERSION };
+}
+

--- a/lib/ai/provider.ts
+++ b/lib/ai/provider.ts
@@ -1,0 +1,67 @@
+import type { Output } from './schemas';
+import { OutputJsonSchema, OutputSchema } from './schemas';
+
+export type ChatMessage = { role: 'system' | 'user' | 'assistant'; content: string };
+
+const MODEL_FREE = process.env.OPENAI_MODEL_FREE || 'gpt-5-2025-08-07';
+const MODEL_PRO = process.env.OPENAI_MODEL_PRO || 'gpt-5-2025-08-07';
+
+async function request(messages: ChatMessage[], model: string, apiKey: string, timeoutMs: number): Promise<Output> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        temperature: 1,
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'kit', schema: OutputJsonSchema },
+        },
+        messages,
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const txt = await res.text().catch(() => '');
+      throw new Error(`OpenAI error: ${res.status} ${txt}`);
+    }
+    const data: any = await res.json();
+    const content = data?.choices?.[0]?.message?.content || '{}';
+    const parsed = JSON.parse(content);
+    return OutputSchema.parse(parsed);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// Call the OpenAI provider with JSON schema validation. Retries once on invalid
+// JSON or schema mismatch.
+export async function callProvider(
+  messages: ChatMessage[],
+  plan: 'FREE' | 'PRO' | 'TEAM' = 'FREE',
+  options?: { timeoutMs?: number }
+): Promise<Output> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY not set');
+  const model = plan === 'FREE' ? MODEL_FREE : MODEL_PRO;
+  const timeoutMs = options?.timeoutMs ?? 15000;
+
+  let lastErr: any;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return await request(messages, model, apiKey, timeoutMs);
+    } catch (err) {
+      lastErr = err;
+      // Retry once on JSON parse or validation errors
+      if (attempt === 0) continue;
+    }
+  }
+  throw lastErr;
+}
+

--- a/lib/ai/schemas.ts
+++ b/lib/ai/schemas.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+// Core facts about the property used by the model.
+export const FactsSchema = z.object({
+  address: z.string().optional(),
+  neighborhood: z.string().optional(),
+  beds: z.string().optional(),
+  baths: z.string().optional(),
+  sqft: z.string().optional(),
+  features: z.array(z.string()).default([]),
+  propertyType: z.string().optional(),
+  tone: z.string().optional(),
+  brandVoice: z.string().optional(),
+});
+export type Facts = z.infer<typeof FactsSchema>;
+
+// Controls for generation. Currently just the subscription plan but leaves
+// room for future knobs.
+export const ControlsSchema = z.object({
+  plan: z.enum(['FREE', 'PRO', 'TEAM']).default('FREE'),
+});
+export type Controls = z.infer<typeof ControlsSchema>;
+
+// Expected marketing outputs from the model.
+export const OutputSchema = z.object({
+  mlsDesc: z.string(),
+  igSlides: z.array(z.string()),
+  reelScript: z.array(z.string()),
+  emailSubject: z.string(),
+  emailBody: z.string(),
+});
+export type Output = z.infer<typeof OutputSchema>;
+
+// JSON schema used for OpenAI's `response_format=json_schema` option.
+export const OutputJsonSchema = {
+  type: 'object',
+  properties: {
+    mlsDesc: { type: 'string' },
+    igSlides: { type: 'array', items: { type: 'string' } },
+    reelScript: { type: 'array', items: { type: 'string' } },
+    emailSubject: { type: 'string' },
+    emailBody: { type: 'string' },
+  },
+  required: ['mlsDesc', 'igSlides', 'reelScript', 'emailSubject', 'emailBody'],
+  additionalProperties: false,
+} as const;
+


### PR DESCRIPTION
## Summary
- define Facts, Controls and Output schemas for AI kit generation
- add OpenAI provider using JSON schema with retry and timeout
- build two-pass generation pipeline with post-processing and compliance scan
- route generateOutputsWithAI through new pipeline

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*


------
https://chatgpt.com/codex/tasks/task_e_689ad7669ff083329fc5578ee8ee8228