### PR TITLE
refactor: adjust AI pipeline to accept pre-built facts

### DIFF
--- a/lib/ai/index.ts
+++ b/lib/ai/index.ts
@@ -1,9 +1,10 @@
 import type { Payload } from '@/lib/generator';
 import type { Outputs } from '@/types/kit';
-import { generateKit } from './pipeline';
+import { buildFacts, generateKit } from './pipeline';
 
 export async function generateOutputsWithAI(payload: Payload, plan: 'FREE' | 'PRO' | 'TEAM' = 'FREE'): Promise<Outputs> {
-  const { outputs } = await generateKit(payload, plan);
-  return outputs;
+  const facts = buildFacts(payload);
+  const { outputs } = await generateKit({ facts, controls: { plan } });
+  return outputs as Outputs;
 }
 

--- a/lib/ai/pipeline.ts
+++ b/lib/ai/pipeline.ts
@@ -1,5 +1,5 @@
 import type { Payload } from '@/lib/generator';
-import type { Output, Facts } from './schemas';
+import type { Output, Facts, Controls } from './schemas';
 import { FactsSchema, OutputSchema } from './schemas';
 import { callProvider, ChatMessage } from './provider';
 
@@ -82,11 +82,14 @@ function complianceScan(o: Output): string[] {
 const PROMPT_VERSION = '1';
 const RULES_VERSION = '1';
 
-export async function generateKit(
-  payload: Payload,
-  plan: 'FREE' | 'PRO' | 'TEAM' = 'FREE'
-): Promise<{ outputs: Output; flags: string[]; promptVersion: string; rulesVersion: string }> {
-  const facts = buildFacts(payload);
+export async function generateKit({
+  facts,
+  controls,
+}: {
+  facts: Facts;
+  controls: Controls;
+}): Promise<{ outputs: Output; flags: string[]; promptVersion: string; rulesVersion: string }> {
+  const plan = controls.plan;
   const draft = await callProvider(composeDraftMessages(facts), plan);
   let final = draft;
   try {


### PR DESCRIPTION
## Summary
- update AI pipeline's `generateKit` to receive pre-built facts and controls
- adapt AI index wrapper to construct facts and forward controls

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx playwright test --project=chromium tests/basic.spec.ts --max-failures=1` *(fails: Executable doesn't exist; run `npx playwright install`)*
- `npx playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689af469796483329f4683a8022c99f4