### PR TITLE
feat: expand demo form options

### DIFF
--- a/app/components/InstantDemoForm.tsx
+++ b/app/components/InstantDemoForm.tsx
@@ -25,6 +25,38 @@ type InstantDemoFormProps = {
   setTone: (v: string) => void;
   brandVoice: string;
   setBrandVoice: (v: string) => void;
+  channels: string[];
+  setChannels: (v: string[]) => void;
+  openHouseDate: string;
+  setOpenHouseDate: (v: string) => void;
+  openHouseTime: string;
+  setOpenHouseTime: (v: string) => void;
+  openHouseLink: string;
+  setOpenHouseLink: (v: string) => void;
+  ctaType: string;
+  setCtaType: (v: string) => void;
+  ctaPhone: string;
+  setCtaPhone: (v: string) => void;
+  ctaLink: string;
+  setCtaLink: (v: string) => void;
+  ctaCustom: string;
+  setCtaCustom: (v: string) => void;
+  socialHandle: string;
+  setSocialHandle: (v: string) => void;
+  hashtagStrategy: string;
+  setHashtagStrategy: (v: string) => void;
+  extraHashtags: string;
+  setExtraHashtags: (v: string) => void;
+  readingLevel: string;
+  setReadingLevel: (v: string) => void;
+  useEmojis: boolean;
+  setUseEmojis: (v: boolean) => void;
+  mlsFormat: string;
+  setMlsFormat: (v: string) => void;
+  mustInclude: string;
+  setMustInclude: (v: string) => void;
+  avoidWords: string;
+  setAvoidWords: (v: string) => void;
   onGenerate: () => void;
   onUseSample: () => void;
   isGenerating?: boolean;
@@ -83,6 +115,22 @@ export default function InstantDemoForm(props: InstantDemoFormProps){
     propertyType, setPropertyType,
     tone, setTone,
     brandVoice, setBrandVoice,
+    channels, setChannels,
+    openHouseDate, setOpenHouseDate,
+    openHouseTime, setOpenHouseTime,
+    openHouseLink, setOpenHouseLink,
+    ctaType, setCtaType,
+    ctaPhone, setCtaPhone,
+    ctaLink, setCtaLink,
+    ctaCustom, setCtaCustom,
+    socialHandle, setSocialHandle,
+    hashtagStrategy, setHashtagStrategy,
+    extraHashtags, setExtraHashtags,
+    readingLevel, setReadingLevel,
+    useEmojis, setUseEmojis,
+    mlsFormat, setMlsFormat,
+    mustInclude, setMustInclude,
+    avoidWords, setAvoidWords,
     onGenerate, onUseSample,
     isGenerating,
   } = props;
@@ -121,6 +169,29 @@ export default function InstantDemoForm(props: InstantDemoFormProps){
       </div>
 
       <div className="mt-6">
+        <div className="text-sm text-white/80">Channels</div>
+        <div className="mt-2 flex flex-wrap gap-4">
+          {['mls', 'instagram', 'reel', 'email'].map((ch) => (
+            <label key={ch} className="inline-flex items-center gap-2 text-sm text-white/80">
+              <input
+                type="checkbox"
+                checked={channels.includes(ch)}
+                onChange={(e) =>
+                  setChannels(
+                    e.target.checked
+                      ? [...channels, ch]
+                      : channels.filter((c) => c !== ch)
+                  )
+                }
+                className="rounded border-white/10 bg-neutral-950"
+              />
+              {ch === 'mls' ? 'MLS' : ch === 'instagram' ? 'Instagram' : ch === 'reel' ? 'Reel' : 'Email'}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6">
         <label className="text-sm text-white/80">Brand voice (paste a past listing — optional)</label>
         <textarea
           value={brandVoice}
@@ -129,6 +200,83 @@ export default function InstantDemoForm(props: InstantDemoFormProps){
           placeholder="E.g., 'Calm, confident tone. Short sentences. Avoid jargon.'"
           className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-3 outline-none focus:ring-2 focus:ring-cyan-400/60"
         />
+      </div>
+
+      <div className="mt-6 grid sm:grid-cols-3 gap-4">
+        <LabeledInput label="Open house date" type="date" value={openHouseDate} onChange={setOpenHouseDate} />
+        <LabeledInput label="Open house time" value={openHouseTime} onChange={setOpenHouseTime} placeholder="11–1" />
+        <LabeledInput label="RSVP link" value={openHouseLink} onChange={setOpenHouseLink} placeholder="https://…" />
+      </div>
+
+      <div className="mt-6 grid sm:grid-cols-3 gap-4">
+        <label className="block">
+          <div className="text-sm text-white/80">CTA type</div>
+          <select
+            value={ctaType}
+            onChange={(e) => setCtaType(e.target.value)}
+            className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-3 outline-none focus:ring-2 focus:ring-cyan-400/60"
+          >
+            <option value="">None</option>
+            <option value="phone">Phone</option>
+            <option value="link">Link</option>
+            <option value="custom">Custom</option>
+          </select>
+        </label>
+        {ctaType === 'phone' && (
+          <LabeledInput label="Phone" value={ctaPhone} onChange={setCtaPhone} placeholder="555-1234" />
+        )}
+        {ctaType === 'link' && (
+          <LabeledInput label="Link" value={ctaLink} onChange={setCtaLink} placeholder="https://…" />
+        )}
+        {ctaType === 'custom' && (
+          <LabeledInput label="Custom text" value={ctaCustom} onChange={setCtaCustom} placeholder="Call me for details" />
+        )}
+      </div>
+
+      <div className="mt-6 grid sm:grid-cols-3 gap-4">
+        <LabeledInput label="Social handle" value={socialHandle} onChange={setSocialHandle} placeholder="@handle" />
+        <LabeledInput label="Hashtag strategy" value={hashtagStrategy} onChange={setHashtagStrategy} placeholder="local + trending" />
+        <LabeledInput label="Extra hashtags" value={extraHashtags} onChange={setExtraHashtags} placeholder="#homes, #realestate" />
+      </div>
+
+      <div className="mt-6 grid sm:grid-cols-3 gap-4">
+        <LabeledInput label="Reading level" value={readingLevel} onChange={setReadingLevel} placeholder="8th grade" />
+        <label className="flex items-center gap-2 text-sm text-white/80 mt-6 sm:mt-0">
+          <input type="checkbox" checked={useEmojis} onChange={(e) => setUseEmojis(e.target.checked)} className="rounded border-white/10 bg-neutral-950" />
+          Use emojis
+        </label>
+        <label className="block">
+          <div className="text-sm text-white/80">MLS format</div>
+          <select
+            value={mlsFormat}
+            onChange={(e) => setMlsFormat(e.target.value)}
+            className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-3 outline-none focus:ring-2 focus:ring-cyan-400/60"
+          >
+            <option value="paragraph">Paragraph</option>
+            <option value="bullets">Bullets</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="mt-6 grid sm:grid-cols-2 gap-4">
+        <label className="block">
+          <div className="text-sm text-white/80">Must include</div>
+          <textarea
+            value={mustInclude}
+            onChange={(e) => setMustInclude(e.target.value)}
+            rows={3}
+            className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-3 outline-none focus:ring-2 focus:ring-cyan-400/60"
+          />
+        </label>
+        <label className="block">
+          <div className="text-sm text-white/80">Avoid words</div>
+          <textarea
+            value={avoidWords}
+            onChange={(e) => setAvoidWords(e.target.value)}
+            rows={3}
+            className="mt-2 w-full rounded-2xl bg-neutral-950 border border-white/10 px-4 py-3 outline-none focus:ring-2 focus:ring-cyan-400/60"
+          />
+        </label>
       </div>
 
       <div className="mt-6 flex flex-wrap items-center gap-3">

--- a/app/hooks/useRealtorKit.ts
+++ b/app/hooks/useRealtorKit.ts
@@ -37,6 +37,22 @@ export function useRealtorKit() {
   const [propertyType, setPropertyType] = useState("Starter Home");
   const [tone, setTone] = useState("Warm & Lifestyle");
   const [brandVoice, setBrandVoice] = useState("");
+  const [channels, setChannels] = useState<string[]>(['mls', 'instagram', 'reel', 'email']);
+  const [openHouseDate, setOpenHouseDate] = useState("");
+  const [openHouseTime, setOpenHouseTime] = useState("");
+  const [openHouseLink, setOpenHouseLink] = useState("");
+  const [ctaType, setCtaType] = useState("");
+  const [ctaPhone, setCtaPhone] = useState("");
+  const [ctaLink, setCtaLink] = useState("");
+  const [ctaCustom, setCtaCustom] = useState("");
+  const [socialHandle, setSocialHandle] = useState("");
+  const [hashtagStrategy, setHashtagStrategy] = useState("");
+  const [extraHashtags, setExtraHashtags] = useState("");
+  const [readingLevel, setReadingLevel] = useState("");
+  const [useEmojis, setUseEmojis] = useState(false);
+  const [mlsFormat, setMlsFormat] = useState("paragraph");
+  const [mustInclude, setMustInclude] = useState("");
+  const [avoidWords, setAvoidWords] = useState("");
 
   // --- Output state ---
   const [generated, setGenerated] = useState(false);
@@ -65,7 +81,33 @@ export function useRealtorKit() {
     setIsGenerating(true);
     try {
       console.log('[useRealtorKit] onGenerate begin');
-      const payload = buildPayloadFromForm({ address, beds, baths, sqft, neighborhood, features, propertyType, tone, brandVoice });
+      const { payload, controls } = buildPayloadFromForm({
+        address,
+        beds,
+        baths,
+        sqft,
+        neighborhood,
+        features,
+        propertyType,
+        tone,
+        brandVoice,
+        channels,
+        openHouseDate,
+        openHouseTime,
+        openHouseLink,
+        ctaType,
+        ctaPhone,
+        ctaLink,
+        ctaCustom,
+        socialHandle,
+        hashtagStrategy,
+        extraHashtags,
+        readingLevel,
+        useEmojis,
+        mlsFormat,
+        mustInclude,
+        avoidWords,
+      });
       console.log('[useRealtorKit] payload', {
         hasAddress: Boolean(address), hasBeds: Boolean(beds), hasBaths: Boolean(baths), hasSqft: Boolean(sqft), hasNeighborhood: Boolean(neighborhood),
         featuresCount: features.split(',').filter(Boolean).length,
@@ -74,7 +116,7 @@ export function useRealtorKit() {
       const res = await fetch('/api/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ payload, controls }),
       });
       if (!res.ok) {
         console.warn('[useRealtorKit] /api/generate failed', { status: res.status });
@@ -234,6 +276,22 @@ export function useRealtorKit() {
     propertyType, setPropertyType,
     tone, setTone,
     brandVoice, setBrandVoice,
+    channels, setChannels,
+    openHouseDate, setOpenHouseDate,
+    openHouseTime, setOpenHouseTime,
+    openHouseLink, setOpenHouseLink,
+    ctaType, setCtaType,
+    ctaPhone, setCtaPhone,
+    ctaLink, setCtaLink,
+    ctaCustom, setCtaCustom,
+    socialHandle, setSocialHandle,
+    hashtagStrategy, setHashtagStrategy,
+    extraHashtags, setExtraHashtags,
+    readingLevel, setReadingLevel,
+    useEmojis, setUseEmojis,
+    mlsFormat, setMlsFormat,
+    mustInclude, setMustInclude,
+    avoidWords, setAvoidWords,
     generated,
     revealed,
     copyToast, setCopyToast,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,6 +28,22 @@ export default function RealtorsAIMarketingKit() {
     propertyType, setPropertyType,
     tone, setTone,
     brandVoice, setBrandVoice,
+    channels, setChannels,
+    openHouseDate, setOpenHouseDate,
+    openHouseTime, setOpenHouseTime,
+    openHouseLink, setOpenHouseLink,
+    ctaType, setCtaType,
+    ctaPhone, setCtaPhone,
+    ctaLink, setCtaLink,
+    ctaCustom, setCtaCustom,
+    socialHandle, setSocialHandle,
+    hashtagStrategy, setHashtagStrategy,
+    extraHashtags, setExtraHashtags,
+    readingLevel, setReadingLevel,
+    useEmojis, setUseEmojis,
+    mlsFormat, setMlsFormat,
+    mustInclude, setMustInclude,
+    avoidWords, setAvoidWords,
     outputs,
     revealed,
     kitSample,
@@ -159,6 +175,22 @@ export default function RealtorsAIMarketingKit() {
                 propertyType={propertyType} setPropertyType={setPropertyType}
                 tone={tone} setTone={setTone}
                 brandVoice={brandVoice} setBrandVoice={setBrandVoice}
+                channels={channels} setChannels={setChannels}
+                openHouseDate={openHouseDate} setOpenHouseDate={setOpenHouseDate}
+                openHouseTime={openHouseTime} setOpenHouseTime={setOpenHouseTime}
+                openHouseLink={openHouseLink} setOpenHouseLink={setOpenHouseLink}
+                ctaType={ctaType} setCtaType={setCtaType}
+                ctaPhone={ctaPhone} setCtaPhone={setCtaPhone}
+                ctaLink={ctaLink} setCtaLink={setCtaLink}
+                ctaCustom={ctaCustom} setCtaCustom={setCtaCustom}
+                socialHandle={socialHandle} setSocialHandle={setSocialHandle}
+                hashtagStrategy={hashtagStrategy} setHashtagStrategy={setHashtagStrategy}
+                extraHashtags={extraHashtags} setExtraHashtags={setExtraHashtags}
+                readingLevel={readingLevel} setReadingLevel={setReadingLevel}
+                useEmojis={useEmojis} setUseEmojis={setUseEmojis}
+                mlsFormat={mlsFormat} setMlsFormat={setMlsFormat}
+                mustInclude={mustInclude} setMustInclude={setMustInclude}
+                avoidWords={avoidWords} setAvoidWords={setAvoidWords}
                 onGenerate={onGenerate}
                 onUseSample={useSample}
                 isGenerating={isGenerating}

--- a/lib/payloadBuilder.ts
+++ b/lib/payloadBuilder.ts
@@ -10,6 +10,22 @@ export function buildPayloadFromForm({
   propertyType,
   tone,
   brandVoice,
+  channels,
+  openHouseDate,
+  openHouseTime,
+  openHouseLink,
+  ctaType,
+  ctaPhone,
+  ctaLink,
+  ctaCustom,
+  socialHandle,
+  hashtagStrategy,
+  extraHashtags,
+  readingLevel,
+  useEmojis,
+  mlsFormat,
+  mustInclude,
+  avoidWords,
 }: {
   address: string;
   beds: string;
@@ -20,7 +36,23 @@ export function buildPayloadFromForm({
   propertyType: string;
   tone: string;
   brandVoice: string;
-}): Payload {
+  channels: string[];
+  openHouseDate: string;
+  openHouseTime: string;
+  openHouseLink: string;
+  ctaType: string;
+  ctaPhone: string;
+  ctaLink: string;
+  ctaCustom: string;
+  socialHandle: string;
+  hashtagStrategy: string;
+  extraHashtags: string;
+  readingLevel: string;
+  useEmojis: boolean;
+  mlsFormat: string;
+  mustInclude: string;
+  avoidWords: string;
+}): { payload: Payload; controls: any } {
   const toStr = (v: string) => (v?.trim() ? v.trim() : undefined);
   const featureList = features
     .split(',')
@@ -38,7 +70,25 @@ export function buildPayloadFromForm({
     propertyType: toStr(propertyType),
     brandVoice: toStr(brandVoice),
   };
-  return payload;
+  const controls = {
+    channels: channels && channels.length ? channels : undefined,
+    openHouseDate: toStr(openHouseDate),
+    openHouseTime: toStr(openHouseTime),
+    openHouseLink: toStr(openHouseLink),
+    ctaType: toStr(ctaType),
+    ctaPhone: toStr(ctaPhone),
+    ctaLink: toStr(ctaLink),
+    ctaCustom: toStr(ctaCustom),
+    socialHandle: toStr(socialHandle),
+    hashtagStrategy: toStr(hashtagStrategy),
+    extraHashtags: toStr(extraHashtags),
+    readingLevel: toStr(readingLevel),
+    useEmojis: useEmojis ? true : undefined,
+    mlsFormat: toStr(mlsFormat),
+    mustInclude: toStr(mustInclude),
+    avoidWords: toStr(avoidWords),
+  };
+  return { payload, controls };
 }
 
 


### PR DESCRIPTION
## Summary
- add optional marketing controls for channels, open house details, CTA, social, readability, and word filters
- track new fields in RealtorKit hook and submit as `controls`
- extend payload builder to include controls alongside payload

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689afad4bb608332b07fd2c8f547a5e8