### PR TITLE
feat: expand generation controls

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -108,7 +108,7 @@ export async function POST(req: Request) {
     console.log('[api/generate] AI generation success', { userId: user.id, kitId: kit.id, ms: latencyMs });
   } catch (e: any) {
     console.error('[api/generate] AI generation failed, falling back', { userId: user.id, kitId: kit.id, error: String(e?.message || e) });
-    const outputsLocal = generateOutputs(payloadData);
+    const outputsLocal = generateOutputs(payloadData, controlsData);
     const latencyMs = Date.now() - startedAt;
     await updateKitReady({
       outputs: outputsLocal,

--- a/lib/ai/pipeline.ts
+++ b/lib/ai/pipeline.ts
@@ -23,7 +23,7 @@ export function buildFacts(payload: Payload): Facts {
   return FactsSchema.parse(raw);
 }
 
-function composeDraftMessages(facts: Facts): ChatMessage[] {
+function composeDraftMessages(facts: Facts, controls: Controls): ChatMessage[] {
   return [
     {
       role: 'system',
@@ -32,7 +32,7 @@ function composeDraftMessages(facts: Facts): ChatMessage[] {
     },
     {
       role: 'user',
-      content: `Facts: ${JSON.stringify(facts)}`,
+      content: `Facts: ${JSON.stringify(facts)}\nControls: ${JSON.stringify(controls)}`,
     },
   ];
 }
@@ -133,7 +133,10 @@ export async function generateKit({
   const plan = controls.plan;
   const policy = controls.policy;
   let tokenCounts: TokenCounts = { prompt: 0, completion: 0, total: 0 };
-  const draftRes = await callProvider(composeDraftMessages(facts), plan);
+  const draftRes = await callProvider(
+    composeDraftMessages(facts, controls),
+    plan
+  );
   tokenCounts.prompt += draftRes.tokenCounts.prompt;
   tokenCounts.completion += draftRes.tokenCounts.completion;
   tokenCounts.total += draftRes.tokenCounts.total;

--- a/lib/ai/schemas.ts
+++ b/lib/ai/schemas.ts
@@ -18,6 +18,20 @@ export type Facts = z.infer<typeof FactsSchema>;
 // room for future knobs.
 export const ControlsSchema = z.object({
   plan: z.enum(['FREE', 'PRO', 'TEAM']).default('FREE'),
+  channels: z.array(z.string()).default([]),
+  openHouseDate: z.string().optional(),
+  openHouseTime: z.string().optional(),
+  openHouseLink: z.string().optional(),
+  ctaType: z.string().optional(),
+  ctaPhone: z.string().optional(),
+  ctaLink: z.string().optional(),
+  ctaCustom: z.string().optional(),
+  socialHandle: z.string().optional(),
+  hashtagStrategy: z.string().optional(),
+  extraHashtags: z.string().optional(),
+  readingLevel: z.string().optional(),
+  useEmojis: z.boolean().default(false),
+  mlsFormat: z.string().optional(),
   policy: z
     .object({
       mustInclude: z.array(z.string()).default([]),

--- a/lib/payloadBuilder.ts
+++ b/lib/payloadBuilder.ts
@@ -1,4 +1,5 @@
 import type { Payload } from '@/lib/generator';
+import type { Controls } from '@/lib/ai/schemas';
 
 export function buildPayloadFromForm({
   address,
@@ -52,7 +53,7 @@ export function buildPayloadFromForm({
   mlsFormat: string;
   mustInclude: string;
   avoidWords: string;
-}): { payload: Payload; controls: any } {
+}): { payload: Payload; controls: Partial<Controls> } {
   const toStr = (v: string) => (v?.trim() ? v.trim() : undefined);
   const featureList = features
     .split(',')
@@ -70,7 +71,7 @@ export function buildPayloadFromForm({
     propertyType: toStr(propertyType),
     brandVoice: toStr(brandVoice),
   };
-  const controls = {
+  const controls: Partial<Controls> = {
     channels: channels && channels.length ? channels : undefined,
     openHouseDate: toStr(openHouseDate),
     openHouseTime: toStr(openHouseTime),

--- a/tests/controls.spec.ts
+++ b/tests/controls.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { buildPayloadFromForm } from '@/lib/payloadBuilder';
+import { ControlsSchema } from '@/lib/ai/schemas';
+import { generateOutputs } from '@/lib/generator';
+
+test('controls survive validation and influence output', () => {
+  const { payload, controls } = buildPayloadFromForm({
+    address: '123 Main St',
+    beds: '3',
+    baths: '2',
+    sqft: '1500',
+    neighborhood: 'Downtown',
+    features: 'garage,pool',
+    propertyType: 'House',
+    tone: 'Friendly',
+    brandVoice: 'Casual',
+    channels: ['mls', 'email', 'instagram'],
+    openHouseDate: 'July 4',
+    openHouseTime: '1-3pm',
+    openHouseLink: 'http://openhouse',
+    ctaType: 'phone',
+    ctaPhone: '555-1234',
+    ctaLink: '',
+    ctaCustom: '',
+    socialHandle: '@realtor',
+    hashtagStrategy: 'local',
+    extraHashtags: '#sale',
+    readingLevel: '8th',
+    useEmojis: true,
+    mlsFormat: 'standard',
+    mustInclude: '',
+    avoidWords: '',
+  });
+
+  const parsed = ControlsSchema.parse(controls);
+  const outputs = generateOutputs(payload, parsed);
+
+  expect(outputs.mlsDesc).toContain('July 4');
+  expect(outputs.mlsDesc).toContain('8th');
+  expect(outputs.mlsDesc).toContain('standard');
+  expect(outputs.mlsDesc).toContain('😊');
+  expect(outputs.emailBody).toContain('Call 555-1234');
+  const lastSlide = outputs.igSlides[outputs.igSlides.length - 1];
+  expect(lastSlide).toContain('@realtor');
+  expect(lastSlide).toContain('#local');
+  expect(lastSlide).toContain('#sale');
+});
+
+test('channels filter outputs', () => {
+  const { payload, controls } = buildPayloadFromForm({
+    address: '123 Main St',
+    beds: '3',
+    baths: '2',
+    sqft: '1500',
+    neighborhood: 'Downtown',
+    features: '',
+    propertyType: '',
+    tone: '',
+    brandVoice: '',
+    channels: ['mls'],
+    openHouseDate: '',
+    openHouseTime: '',
+    openHouseLink: '',
+    ctaType: '',
+    ctaPhone: '',
+    ctaLink: '',
+    ctaCustom: '',
+    socialHandle: '',
+    hashtagStrategy: '',
+    extraHashtags: '',
+    readingLevel: '',
+    useEmojis: false,
+    mlsFormat: '',
+    mustInclude: '',
+    avoidWords: '',
+  });
+
+  const parsed = ControlsSchema.parse(controls);
+  const outputs = generateOutputs(payload, parsed);
+  expect(outputs.igSlides).toHaveLength(0);
+  expect(outputs.reelScript).toHaveLength(0);
+  expect(outputs.emailSubject).toBe('');
+  expect(outputs.emailBody).toBe('');
+  expect(outputs.mlsDesc).not.toBe('');
+});


### PR DESCRIPTION
## Summary
- extend ControlsSchema with channels, open house details, CTA fields, social hashtags, reading level, emojis, and MLS format
- pass new controls through payload builder, API, and AI pipeline
- update local generator to honor controls and add unit tests

## Testing
- `npx playwright test tests/controls.spec.ts`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689b6732dba88332bbb2ec167f057c42