### PR TITLE
Use production server for Playwright and add smoke test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Provide default values for required environment variables so that the
+// Next.js app can start during tests without relying on external secrets.
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= 'http://localhost:54321';
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= 'public-anon-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= 'service-role-key';
+
 // Use process.env.PORT by default and fallback to 3000 if not specified.
 const PORT = process.env.PORT || 3000;
 
@@ -48,9 +54,9 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
+  /* Run a production build before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: 'npm run build && npm run start',
     url: baseURL,
     timeout: 120 * 1000,
     reuseExistingServer: !process.env.CI,

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('landing page renders', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByText("Realtor's AI Marketing Kit")).toBeVisible();
+});
+


### PR DESCRIPTION
## Summary
- ensure Playwright starts production build by running `npm run build && npm run start`
- provide default Supabase env vars so tests can boot
- add a smoke test that verifies the landing page renders

## Testing
- `npx playwright test tests/smoke.spec.ts --reporter=list` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npx playwright install --with-deps` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b768a4a4c8332b65c3e30e13949ba