### PR TITLE
Compute property summary

### DIFF
--- a/lib/ai/pipeline.ts
+++ b/lib/ai/pipeline.ts
@@ -25,6 +25,18 @@ export function buildFacts(payload: Payload): Facts {
     tone: payload.tone?.trim(),
     brandVoice: payload.brandVoice?.trim(),
   } as Record<string, any>;
+  const parts = [
+    raw.beds && `${raw.beds} bed`,
+    raw.baths && `${raw.baths} bath`,
+    raw.propertyType,
+  ].filter(Boolean) as string[];
+  let summary = parts.join(' ');
+  if (raw.neighborhood) {
+    summary = summary
+      ? `${summary} in ${raw.neighborhood}`
+      : raw.neighborhood;
+  }
+  raw.summary = summary || undefined;
   return FactsSchema.parse(raw);
 }
 

--- a/lib/ai/schemas.ts
+++ b/lib/ai/schemas.ts
@@ -12,6 +12,7 @@ export const FactsSchema = z.object({
   propertyType: z.string().optional(),
   tone: z.string().optional(),
   brandVoice: z.string().optional(),
+  summary: z.string().optional(),
 });
 export type Facts = z.infer<typeof FactsSchema>;
 


### PR DESCRIPTION
## Summary
- generate a short property summary from beds, baths, property type, and neighborhood in buildFacts
- allow summary field in Facts schema so it reaches the model prompt

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ecb89926083328ff9144f78350c58